### PR TITLE
ci: use user details when updating master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Commit changes to the master branch
       run: |
         cd master
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
+        git config --local user.email "${{ github.event.pusher.email }}"
+        git config --local user.name "${{ github.event.pusher.username }}"
         git add .
         git commit -m "Update master to output generated at ${{ github.sha }}" --allow-empty
     - name: Push changes


### PR DESCRIPTION
Hopefully this fixes github pages not automatically updating
